### PR TITLE
Add Tailwind CSS build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To start using all the tools that come with `_s`  you need to install the necess
 ```sh
 $ composer install
 $ npm install
+$ npm run build:css
 ```
 
 ### Available CLI commands
@@ -59,6 +60,7 @@ $ npm install
 - `composer lint:php` : checks all PHP files for syntax errors.
 - `composer make-pot` : generates a .pot file in the `languages/` directory.
 - `npm run compile:css` : compiles SASS files to css.
+- `npm run build:css` : generates the Tailwind CSS stylesheet.
 - `npm run compile:rtl` : generates an RTL stylesheet.
 - `npm run watch` : watches all SASS files and recompiles them to css when they change.
 - `npm run lint:scss` : checks all SASS files against [CSS Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "@wordpress/scripts": "^19.2.2",
     "dir-archiver": "^1.1.1",
     "node-sass": "^7.0.1",
-    "rtlcss": "^3.5.0"
+    "rtlcss": "^3.5.0",
+    "tailwindcss": "^3.4.4",
+    "postcss-cli": "^10.1.0",
+    "autoprefixer": "^10.4.0"
   },
   "rtlcssConfig": {
     "options": {
@@ -39,6 +42,7 @@
     "watch": "node-sass sass/ -o ./ --source-map true --output-style expanded --indent-type tab --indent-width 1 -w",
     "compile:css": "node-sass sass/ -o ./ && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
     "compile:rtl": "rtlcss style.css style-rtl.css",
+    "build:css": "tailwindcss -i src/tailwind.css -o style.css --minify",
     "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
     "lint:js": "wp-scripts lint-js 'js/*.js'",
     "bundle": "dir-archiver --src . --dest ../_s.zip --exclude .DS_Store .stylelintrc.json .eslintrc .git .gitattributes .github .gitignore README.md composer.json composer.lock node_modules vendor package-lock.json package.json .travis.yml phpcs.xml.dist sass style.css.map yarn.lock"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ],
+};

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './*.php',
+    './template-parts/**/*.php',
+    './inc/**/*.php'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind-related dev dependencies and build script
- document Tailwind build command in README
- add Tailwind config, PostCSS config and source CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d62876060832193820e40eae71318